### PR TITLE
Sanitise species names with partial matches of invalid terms correctly

### DIFF
--- a/R/bd_retrieve_data.R
+++ b/R/bd_retrieve_data.R
@@ -62,10 +62,13 @@ sanitise_term <- function(searchTerm, searchType) {
     pattern = "[^[:alnum:] ]",
     x = searchTerm,
     ignore.case = TRUE
-  ) |
-    grepl("\\b(true|false|nil)\\b", searchTerm, ignore.case = TRUE)) {
+  )) {
     stop(
       "Illegal character detected! My apologies, but your search can only contain letters, numbers and white-space. Abbreviating genus names (e.g. 'B. subtilis') is not supported. Please spell out your searchTerm ('Bacillus subtilis'), don't use any 'special' characters and try again."
+    )
+  } else if (grepl("\\b(true|false|nil)\\b", searchTerm, ignore.case = TRUE)) {
+    stop(
+      "Invalid search term! My apologies, but your search can not contain only 'true', 'false' or 'nil."
     )
   } else if (identical(searchType, "taxon") & grepl("\\s", searchTerm)) {
     gsub(pattern = "\\s", replacement = "/", searchTerm)

--- a/R/bd_retrieve_data.R
+++ b/R/bd_retrieve_data.R
@@ -63,7 +63,7 @@ sanitise_term <- function(searchTerm, searchType) {
     x = searchTerm,
     ignore.case = TRUE
   ) |
-    grepl("(true|false|nil)", searchTerm, ignore.case = TRUE)) {
+    grepl("\\b(true|false|nil)\\b", searchTerm, ignore.case = TRUE)) {
     stop(
       "Illegal character detected! My apologies, but your search can only contain letters, numbers and white-space. Abbreviating genus names (e.g. 'B. subtilis') is not supported. Please spell out your searchTerm ('Bacillus subtilis'), don't use any 'special' characters and try again."
     )

--- a/tests/testthat/test-sanitise_input.R
+++ b/tests/testthat/test-sanitise_input.R
@@ -10,4 +10,5 @@ test_that("Taxon species is escaped to taxon/species", {
 
 test_that("Normal searchTerm is return without sanitation", {
   expect_identical(sanitise_term("Bacillus", "taxon"), "Bacillus")
+  expect_identical(sanitise_term("Cellulomonas xylanilytica", "taxon"), "Cellulomonas/xylanilytica")
 })

--- a/tests/testthat/test-sanitise_input.R
+++ b/tests/testthat/test-sanitise_input.R
@@ -12,3 +12,9 @@ test_that("Normal searchTerm is return without sanitation", {
   expect_identical(sanitise_term("Bacillus", "taxon"), "Bacillus")
   expect_identical(sanitise_term("Cellulomonas xylanilytica", "taxon"), "Cellulomonas/xylanilytica")
 })
+
+test_that("Invalid search terms cause errors", {
+  expect_error(sanitise_term("true", "taxon"))
+  expect_error(sanitise_term("false", "taxon"))
+  expect_error(sanitise_term("nil", "taxon"))
+})


### PR DESCRIPTION
<!--
Please start with a brief summary. If your suggestion is straightforward,
"See diff" and deleting the rest of the template text is fine :-)
-->

Fixes #116 quickly. Thanks for the hint, @gregpoore! Please try installing the package from this ref `116-repair-invalid-search-term`.

Before merging, I should check, whether BacDive itself hiccups on the input example I'm sanitising here.

<!--
If your PR includes more substantial changes, please explain them above and then
mark the relevant boxes below (with an x). Deleting, or moving irrelevant lines
down without the [ ], and/or striking them out with ~~...~~ is fine :-)
-->

#### I have...

- [x] ... run `make check` in the terminal and saw now errors.
- [x] ... added/updated tests to [`https://github.com/TIBHannover/BacDiveR/tree/master/tests/testthat/`](https://github.com/TIBHannover/BacDiveR/tree/master/tests/testthat) for new features or bug-fixes.
- [ ] ... updated the [changelog / `NEWS.md` in the `Unreleased` section](https://github.com/TIBHannover/BacDiveR/blob/master/NEWS.md#unreleased), if my PR introduces user-facing changes.
- [x] ... read (at least) the [license] and agreed that it will apply to my contribution as well. 

[license]: https://tibhannover.github.io/BacDiveR/LICENSE-text.html

#### If this is a release PR, additionally

- [ ] Move [`Unreleased` changes in `NEWS.md` to dedicated section](https://github.com/TIBHannover/BacDiveR/blob/master/NEWS.md#unreleased)
- [ ] Copy those & the new version number to [new GitHub release](https://github.com/TIBHannover/BacDiveR/releases/new), together with the
[`README.md`'s 1st paragraph](https://github.com/TIBHannover/BacDiveR/blame/master/README.md#L22-L24)
- [ ] Increment the [SemVer.org] [number in the `DESCRIPTION` file](https://github.com/TIBHannover/BacDiveR/blob/master/DESCRIPTION#L4).

[SemVer.org]: https://semver.org/

<!-- Thank you! -->
